### PR TITLE
Finalize issue #13 persistence docs and DB path config

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,19 +6,28 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Persist activities and participants in SQLite across restarts
+- Automatically apply schema migrations at startup
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r requirements.txt
    ```
 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn app:app --reload
+   ```
+
+   Optional: customize the database location:
+
+   ```
+   export SCHOOL_DB_PATH=/path/to/school_activities.db
+   uvicorn app:app --reload
    ```
 
 3. Open your browser and go to:
@@ -31,6 +40,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student from an activity                               |
 
 ## Data Model
 
@@ -47,4 +57,5 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+Data is persisted in SQLite, so activities and sign-ups survive server restarts.
+The database file defaults to `src/school_activities.db` and can be overridden with `SCHOOL_DB_PATH`.

--- a/src/app.py
+++ b/src/app.py
@@ -20,7 +20,15 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-DATABASE_PATH = current_dir / "school_activities.db"
+
+def get_database_path() -> Path:
+    configured_path = os.getenv("SCHOOL_DB_PATH")
+    if configured_path:
+        return Path(configured_path).expanduser().resolve()
+    return (current_dir / "school_activities.db").resolve()
+
+
+DATABASE_PATH = get_database_path()
 LATEST_SCHEMA_VERSION = 1
 
 SEED_ACTIVITIES = {
@@ -126,7 +134,10 @@ def apply_migrations(conn: sqlite3.Connection) -> None:
 
     latest_version = conn.execute("PRAGMA user_version").fetchone()[0]
     if latest_version != LATEST_SCHEMA_VERSION:
-        raise RuntimeError("Database schema version mismatch")
+        raise RuntimeError(
+            "Database schema version mismatch: "
+            f"expected {LATEST_SCHEMA_VERSION}, got {latest_version}"
+        )
 
 
 def seed_initial_data(conn: sqlite3.Connection) -> None:


### PR DESCRIPTION
## Summary
- add configurable SQLite database path via `SCHOOL_DB_PATH` environment variable
- improve migration version mismatch error details
- update `src/README.md` to reflect persistent storage, migration behavior, and full API endpoints

## Why
Issue #13 asks for persistent storage with schema support and stable endpoints. The backend implementation already uses SQLite; this PR finalizes operational clarity and deployment flexibility without breaking existing API behavior.

## Validation
- ran a Python persistence check using a temporary DB path and module reload
- confirmed sign-up persisted across reload (`persisted: True`)

## Related
- Closes #13